### PR TITLE
Add timeout to action inputs

### DIFF
--- a/action.py
+++ b/action.py
@@ -23,6 +23,7 @@ def load_inputs():
         "release",
         "repo-name",
         "repo",
+        "timeout",
         "values-files",
         "values"
     ]:
@@ -104,6 +105,8 @@ def helm_install(wrkdir, specs):
         params.extend(["-f", values_target])
     if specs["chart-version"]:
         params.extend(["--version", specs["chart-version"]])
+    if specs["timeout"]:
+        params.extend("--timeout", specs["timeout"])
     run_helm("install", params)
 
 
@@ -129,6 +132,8 @@ def helm_upgrade(wrkdir, specs):
         params.extend(["-f", values_target])
     if specs["chart-version"]:
         params.extend(["--version", specs["chart-version"]])
+    if specs["timeout"]:
+        params.extend("--timeout", specs["timeout"])
     run_helm("upgrade", params)
 
 

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
     description: "Apply Helm --atomic flag. (default: true)"
     required: false
     default: true
+  timeout:
+    description: "Apply Helm --timeout flag."
+    required: false
   helm-version:
     description: "Helm version to use. (default: latest)"
     required: false
@@ -91,6 +94,7 @@ runs:
         export GHINPUT_RELEASE="${{ inputs.release }}"
         export GHINPUT_REPO_NAME="${{ inputs.repo-name }}"
         export GHINPUT_REPO="${{ inputs.repo }}"
+        export GHINPUT_TIMEOUT="${{ inputs.timeout }}"
         export GHINPUT_VALUES_FILES="${{ inputs.values-files }}"
         export GHINPUT_VALUES="${{ inputs.values }}"
 


### PR DESCRIPTION
Sometimes happens that helm rolls back due to timeout. I've seen this in two cases:
- pods that takes a lot to startup
- cluster scale up needed to release the new version of the app

Having the ability to configure helm timeout helps us managing those cases